### PR TITLE
Add two more operations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile "com.algorithmjunkie.mc:konfig-bukkit:1.0.0"
     compileOnly "org.spigotmc:spigot-api:1.13.2-R0.1-SNAPSHOT"
     compileOnly "com.hm.achievement:advanced-achievements-api:1.1.0"
-    compileOnly "me.lucko.luckperms:luckperms-api:4.3"
+    compileOnly "me.lucko.luckperms:luckperms-api:4.4"
 }
 
 compileKotlin {

--- a/src/main/kotlin/gg/vale/code/aalphook/AALPHookConfig.kt
+++ b/src/main/kotlin/gg/vale/code/aalphook/AALPHookConfig.kt
@@ -16,6 +16,8 @@ class AALPHookConfig(private val plugin: AALPHookPlugin) : BukkitKonfig(plugin, 
                     val actionType= when (actionToGroup[0].toLowerCase().trim()) {
                         "addgroup" -> LuckPermsActionType.ADDGROUP
                         "delgroup" -> LuckPermsActionType.DELGROUP
+                        "addperm" -> LuckPermsActionType.ADDPERM
+                        "delperm" -> LuckPermsActionType.DELPERM
                         else -> throw RuntimeException("Unknown Action Type was found and could not be decoded.")
                     }
 
@@ -48,6 +50,8 @@ class AALPHookConfig(private val plugin: AALPHookPlugin) : BukkitKonfig(plugin, 
 
     enum class LuckPermsActionType {
         ADDGROUP,
-        DELGROUP;
+        DELGROUP,
+        ADDPERM,
+        DELPERM;
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: AdvancedAchievements-LuckPerms-Hook
 description: A middleman plugin to listen for AdvancedAchievements and LuckPerms events and coordinate between the two
-version: 1.0.2
+version: 1.0.3
 authors: [simpleauthority]
 depend: [AdvancedAchievements, LuckPerms]
 main: gg.vale.code.aalphook.AALPHookPlugin


### PR DESCRIPTION
Adds the addperm and delperm functionality to the plugin. Use this to assign and unassign simple permission nodes.